### PR TITLE
feat: centering emoji & image width 100%

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: build npm project
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+      - name: npm install, build, and test
+        run: |
+          npm install
+          npm run postinstall
+          npm run build

--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
             "eslint --fix",
             "prettier --write"
         ]
+    },
+    "volta": {
+        "node": "18.16.0"
     }
 }

--- a/src/components/Tweet.tsx
+++ b/src/components/Tweet.tsx
@@ -1,4 +1,10 @@
-import { useState, useEffect, useContext } from 'react'
+import {
+    useState,
+    useEffect,
+    useContext,
+    type ImgHTMLAttributes,
+    type DetailedHTMLProps
+} from 'react'
 import {
     ListItem,
     Box,
@@ -21,6 +27,7 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import rehypeRaw from 'rehype-raw'
 import rehypeSanitize from 'rehype-sanitize'
+import { type ReactMarkdownProps } from 'react-markdown/lib/ast-to-react'
 
 export interface TweetProps {
     message: string
@@ -201,12 +208,38 @@ export function Tweet(props: TweetProps): JSX.Element {
                                                 {children}
                                             </Typography>
                                         ),
-                                        img: (props) => (
-                                            <img
-                                                {...props}
-                                                style={{ maxWidth: '100%' }}
-                                            />
-                                        )
+                                        img: (
+                                            props: Pick<
+                                                DetailedHTMLProps<
+                                                    ImgHTMLAttributes<HTMLImageElement>,
+                                                    HTMLImageElement
+                                                >,
+                                                | 'key'
+                                                | keyof ImgHTMLAttributes<HTMLImageElement>
+                                            > &
+                                                ReactMarkdownProps
+                                        ) => {
+                                            if (
+                                                props.alt?.startsWith('emoji')
+                                            ) {
+                                                return (
+                                                    <img
+                                                        {...props}
+                                                        style={{
+                                                            height: '1.5em',
+                                                            verticalAlign:
+                                                                '-0.5em'
+                                                        }}
+                                                    />
+                                                )
+                                            }
+                                            return (
+                                                <img
+                                                    {...props}
+                                                    style={{ maxWidth: '100%' }}
+                                                />
+                                            )
+                                        }
                                     }}
                                 >
                                     {JSON.parse(message.payload).body?.replace(
@@ -219,9 +252,9 @@ export function Tweet(props: TweetProps): JSX.Element {
                                             if (emoji) {
                                                 return `<img 
                                                     title=":${emoji?.name}:"
-                                                    alt=":${emoji?.name}:"
+                                                    alt="emoji:${emoji?.name}:"
                                                     src="${emoji?.publicUrl}"
-                                                    height="18px" />`
+                                                    />`
                                             }
                                             return `${name}`
                                         }

--- a/src/pages/Timeline.tsx
+++ b/src/pages/Timeline.tsx
@@ -110,7 +110,7 @@ export function Timeline(props: TimelineProps): JSX.Element {
                     />
                 </Box>
                 <Box sx={{ display: 'flex', flex: 1 }}>
-                    <List sx={{ flex: 1 }}>
+                    <List sx={{ flex: 1, width: '100%' }}>
                         {props.messages.current
                             .slice()
                             .reverse()


### PR DESCRIPTION
fix: #31 
絵文字を真ん中にしました。
対応がガバい[(ここ)](https://github.com/totegamma/concurrent-web/compare/master...rassi0429:concurrent-web:dev/kokoa#diff-a92eab4dad73be482dce3a635e342b91239b1372d86b3f16916573a7dc2ca171R223)ので、おそらくTODO案件だと思います。
![image](https://user-images.githubusercontent.com/91118218/236395925-3dd46ca1-8ac4-4166-8f35-84e40aaa285d.png)
