### PR TITLE
Feat/handle stream as object

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,10 @@ import {
 
 import { usePersistent } from './hooks/usePersistent'
 import { useObjectList } from './hooks/useObjectList'
-import { useResourceManager } from './hooks/useResourceManager'
+import {
+    useResourceManager,
+    type IuseResourceManager
+} from './hooks/useResourceManager'
 
 import { Schemas } from './schemas'
 import { Themes } from './themes'
@@ -22,7 +25,8 @@ import type {
     User,
     ServerEvent,
     Association,
-    Emoji
+    Emoji,
+    Stream
 } from './model'
 import {
     Associations,
@@ -50,7 +54,8 @@ export const ApplicationContext = createContext<appData>({
         homestream: '',
         notificationstream: ''
     },
-    emojiDict: {}
+    emojiDict: {},
+    streamDict: undefined
 })
 
 export interface appData {
@@ -60,6 +65,7 @@ export interface appData {
     userAddress: string
     profile: User
     emojiDict: Record<string, Emoji>
+    streamDict?: IuseResourceManager<Stream>
 }
 
 function App(): JSX.Element {
@@ -158,6 +164,15 @@ function App(): JSX.Element {
         })
         const data = await res.json()
         return data.message
+    })
+
+    const streamDict = useResourceManager<Stream>(async (key: string) => {
+        const res = await fetch(server + `stream?stream=${key}`, {
+            method: 'GET',
+            headers: {}
+        })
+        const data = await res.json()
+        return data
     })
 
     const follow = (ccaddress: string): void => {
@@ -277,7 +292,8 @@ function App(): JSX.Element {
                     privatekey: prvkey,
                     userAddress: address,
                     emojiDict,
-                    profile
+                    profile,
+                    streamDict
                 }}
             >
                 <BrowserRouter>

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -4,7 +4,6 @@ import {
     List,
     ListItem,
     ListItemButton,
-    ListItemIcon,
     ListItemText,
     Typography
 } from '@mui/material'
@@ -17,12 +16,32 @@ import ExploreIcon from '@mui/icons-material/Explore'
 import SettingsIcon from '@mui/icons-material/Settings'
 import NotificationsIcon from '@mui/icons-material/Notifications'
 import PercentIcon from '@mui/icons-material/Percent'
+import { useContext, useEffect, useState } from 'react'
+import { ApplicationContext } from '../App'
+import { type Stream } from '../model'
 
 export interface MenuProps {
     streams: string[]
 }
 
 export function Menu(props: MenuProps): JSX.Element {
+    const appData = useContext(ApplicationContext)
+    const [watchStreams, setWatchStreams] = useState<Stream[]>([])
+
+    useEffect(() => {
+        ;(async () => {
+            setWatchStreams(
+                (
+                    await Promise.all(
+                        props.streams.map(
+                            async (id) => await appData.streamDict?.get(id)
+                        )
+                    )
+                ).filter((e) => e) as Stream[]
+            )
+        })()
+    }, [props.streams])
+
     return (
         <Box sx={{ gap: '15px', height: '100%' }}>
             <Box
@@ -133,19 +152,21 @@ export function Menu(props: MenuProps): JSX.Element {
                             flexDirection: 'column'
                         }}
                     >
-                        {props.streams.map((value) => {
-                            const labelId = `checkbox-list-secondary-label-${value}`
+                        {watchStreams.map((stream) => {
+                            const labelId = `checkbox-list-secondary-label-${stream.id}`
                             return (
-                                <ListItem key={value} disablePadding>
+                                <ListItem key={stream.id} disablePadding>
                                     <ListItemButton
                                         component={Link}
-                                        to={`/#${value}`}
+                                        to={`/#${stream.id}`}
                                         sx={{ gap: 1 }}
                                     >
                                         <PercentIcon sx={{ color: 'white' }} />
                                         <ListItemText
                                             id={labelId}
-                                            primary={value}
+                                            primary={
+                                                JSON.parse(stream.meta).name
+                                            }
                                         />
                                     </ListItemButton>
                                 </ListItem>

--- a/src/components/Tweet.tsx
+++ b/src/components/Tweet.tsx
@@ -69,7 +69,9 @@ export function Tweet(props: TweetProps): JSX.Element {
                             async (id) =>
                                 await appData.streamDict
                                     ?.get(id)
-                                    .then((e) => JSON.parse(e.meta).name)
+                                    .then((e) =>
+                                        e.meta ? JSON.parse(e.meta).name : null
+                                    )
                         )
                 ).then((e) => {
                     setStreams(e.filter((x) => x).join(','))

--- a/src/components/Tweet.tsx
+++ b/src/components/Tweet.tsx
@@ -40,6 +40,7 @@ export interface TweetProps {
 export function Tweet(props: TweetProps): JSX.Element {
     const [user, setUser] = useState<User | null>()
     const [message, setMessage] = useState<RTMMessage | undefined>()
+    const [msgstreams, setStreams] = useState<string>('')
 
     const appData = useContext(ApplicationContext)
 
@@ -60,6 +61,19 @@ export function Tweet(props: TweetProps): JSX.Element {
                     .catch((error) => {
                         console.error(error)
                     })
+
+                Promise.all(
+                    msg.streams
+                        .split(',')
+                        .map(
+                            async (id) =>
+                                await appData.streamDict
+                                    ?.get(id)
+                                    .then((e) => JSON.parse(e.meta).name)
+                        )
+                ).then((e) => {
+                    setStreams(e.filter((x) => x).join(','))
+                })
             })
             .catch((error) => {
                 console.error(error)
@@ -192,7 +206,7 @@ export function Tweet(props: TweetProps): JSX.Element {
                                         color: '#aaa'
                                     }}
                                 >
-                                    %{message.streams.replaceAll(',', ' %')}{' '}
+                                    %{msgstreams.replaceAll(',', ' %')}{' '}
                                 </Typography>
                             </Typography>
                         </Box>

--- a/src/model.ts
+++ b/src/model.ts
@@ -46,3 +46,15 @@ export interface Emoji {
     publicUrl: string
     name: string
 }
+
+export interface Stream {
+    id: string
+    author: string
+    maintainer: string[]
+    writer: string[]
+    reader: string[]
+    schema: string
+    meta: string
+    signature: string
+    cdate: string
+}

--- a/src/pages/Explorer.tsx
+++ b/src/pages/Explorer.tsx
@@ -9,6 +9,7 @@ import {
     ListItemButton,
     ListItemIcon,
     ListItemText,
+    TextField,
     Typography,
     useTheme
 } from '@mui/material'
@@ -17,7 +18,8 @@ import { ApplicationContext } from '../App'
 import StarIcon from '@mui/icons-material/Star'
 import StarBorderIcon from '@mui/icons-material/StarBorder'
 import type { IuseResourceManager } from '../hooks/useResourceManager'
-import type { User } from '../model'
+import type { Stream, User } from '../model'
+import { Sign } from '../util'
 
 export interface ExplorerProps {
     watchList: string[]
@@ -31,15 +33,53 @@ export function Explorer(props: ExplorerProps): JSX.Element {
     const theme = useTheme()
 
     const appData = useContext(ApplicationContext)
-    const [streams, setStreams] = useState<string[]>([])
+    const [streams, setStreams] = useState<Stream[]>([])
     const [followList, setFollowList] = useState<User[]>([])
+    const [newStreamName, setNewStreamName] = useState<string>('')
 
-    useEffect(() => {
-        fetch(appData.serverAddress + 'stream/list').then((data) => {
+    const loadStreams = (): void => {
+        fetch(
+            appData.serverAddress +
+                'stream/list?schema=net.gammalab.concurrent.tbdStreamMeta'
+        ).then((data) => {
             data.json().then((json) => {
                 setStreams(json)
             })
         })
+    }
+
+    const createNewStream = (name: string): void => {
+        const payloadObj = {
+            name
+        }
+
+        const payload = JSON.stringify(payloadObj)
+        const signature = Sign(appData.privatekey, payload)
+
+        const requestOptions = {
+            method: 'PUT',
+            headers: {},
+            body: JSON.stringify({
+                author: appData.userAddress,
+                maintainer: [],
+                writer: [],
+                reader: [],
+                schema: 'net.gammalab.concurrent.tbdStreamMeta',
+                meta: payload,
+                signature
+            })
+        }
+
+        fetch(appData.serverAddress + 'stream', requestOptions)
+            .then(async (res) => await res.json())
+            .then((data) => {
+                console.log(data)
+                loadStreams()
+            })
+    }
+
+    useEffect(() => {
+        loadStreams()
     }, [])
 
     useEffect(() => {
@@ -77,29 +117,48 @@ export function Explorer(props: ExplorerProps): JSX.Element {
             <Typography variant="h6" gutterBottom>
                 streams
             </Typography>
+            <Box sx={{ display: 'flex', gap: '10px' }}>
+                <TextField
+                    label="stream name"
+                    variant="outlined"
+                    value={newStreamName}
+                    sx={{ flexGrow: 1 }}
+                    onChange={(e) => {
+                        setNewStreamName(e.target.value)
+                    }}
+                />
+                <Button
+                    variant="contained"
+                    onClick={(_) => {
+                        createNewStream(newStreamName)
+                    }}
+                >
+                    Create
+                </Button>
+            </Box>
             <List dense sx={{ width: '100%', maxWidth: 360 }}>
                 {streams.map((value) => {
-                    const labelId = `checkbox-list-secondary-label-${value}`
+                    const labelId = `checkbox-list-secondary-label-${value.id}`
                     return (
-                        <ListItem key={value} disablePadding>
+                        <ListItem key={value.id} disablePadding>
                             <ListItemButton
                                 onClick={() => {
-                                    if (props.watchList.includes(value)) {
+                                    if (props.watchList.includes(value.id)) {
                                         props.setWatchList(
                                             props.watchList.filter(
-                                                (e) => e !== value
+                                                (e) => e !== value.id
                                             )
                                         )
                                     } else {
                                         props.setWatchList([
                                             ...props.watchList,
-                                            value
+                                            value.id
                                         ])
                                     }
                                 }}
                             >
                                 <ListItemIcon>
-                                    {props.watchList.includes(value) ? (
+                                    {props.watchList.includes(value.id) ? (
                                         <StarIcon
                                             sx={{
                                                 color: theme.palette.text
@@ -117,7 +176,9 @@ export function Explorer(props: ExplorerProps): JSX.Element {
                                 </ListItemIcon>
                                 <ListItemText
                                     id={labelId}
-                                    primary={`%${value}`}
+                                    primary={`%${
+                                        JSON.parse(value.meta).name as string
+                                    }`}
                                 />
                             </ListItemButton>
                         </ListItem>

--- a/src/pages/Timeline.tsx
+++ b/src/pages/Timeline.tsx
@@ -45,7 +45,7 @@ export function Timeline(props: TimelineProps): JSX.Element {
         }
         const url =
             appData.serverAddress +
-            `stream?streams=${
+            `stream/recent?streams=${
                 reactlocation.hash
                     ? reactlocation.hash.replace('#', '')
                     : homequery
@@ -60,7 +60,7 @@ export function Timeline(props: TimelineProps): JSX.Element {
             .then(async (res) => await res.json())
             .then((data: StreamElement[]) => {
                 props.messages.clear()
-                data.sort((a, b) => (a.ID < b.ID ? -1 : 1)).forEach(
+                data?.sort((a, b) => (a.ID < b.ID ? -1 : 1)).forEach(
                     (e: StreamElement) => {
                         props.messages.push(e)
                     }


### PR DESCRIPTION
streamの識別は今まで名前そのままでしたが、これだと

- streamに説明文やアイコンを設定できない
- streamの書き込み・読み込み権限を設定できない
- 同名のstreamを作成できない

という問題があります。
なので、streamをオブジェクトとしてラップしました。これはバックエンドの変更に追従するものとなります。
