### PR TITLE
fext: messageDictとuserDictをcontextに移動する

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, createContext, useRef } from 'react'
+import { useEffect, useState, useCallback, createContext, useRef } from 'react'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { darken, Box, Paper, ThemeProvider } from '@mui/material'
 
@@ -6,6 +6,7 @@ import { usePersistent } from './hooks/usePersistent'
 import { useObjectList } from './hooks/useObjectList'
 import {
     useResourceManager,
+    dummyResourceManager,
     type IuseResourceManager
 } from './hooks/useResourceManager'
 
@@ -49,7 +50,9 @@ export const ApplicationContext = createContext<appData>({
         notificationstream: ''
     },
     emojiDict: {},
-    streamDict: undefined
+    streamDict: undefined,
+    userDict: dummyResourceManager,
+    messageDict: dummyResourceManager
 })
 
 export interface appData {
@@ -60,6 +63,8 @@ export interface appData {
     profile: User
     emojiDict: Record<string, Emoji>
     streamDict?: IuseResourceManager<Stream>
+    userDict: IuseResourceManager<User>
+    messageDict: IuseResourceManager<RTMMessage>
 }
 
 function App(): JSX.Element {
@@ -116,48 +121,58 @@ function App(): JSX.Element {
             })
     }, [])
 
-    const userDict = useResourceManager<User>(async (key: string) => {
-        const res = await fetch(
-            server +
-                'characters?author=' +
-                encodeURIComponent(key) +
-                '&schema=' +
-                encodeURIComponent(Schemas.profile),
-            {
-                method: 'GET',
-                headers: {}
-            }
+    const userDict = useResourceManager<User>(
+        useCallback(
+            async (key: string) => {
+                const res = await fetch(
+                    server +
+                        'characters?author=' +
+                        encodeURIComponent(key) +
+                        '&schema=' +
+                        encodeURIComponent(Schemas.profile),
+                    {
+                        method: 'GET',
+                        headers: {}
+                    }
+                )
+                const data = await res.json()
+                if (data.characters.length === 0) {
+                    return {
+                        ccaddress: '',
+                        username: 'anonymous',
+                        avatar: '',
+                        description: '',
+                        homestream: '',
+                        notificationstream: ''
+                    }
+                }
+                const payload = JSON.parse(data.characters[0].payload)
+                return {
+                    ccaddress: data.characters[0].author,
+                    username: payload.username,
+                    avatar: payload.avatar,
+                    description: payload.description,
+                    homestream: payload.home,
+                    notificationstream: payload.notification
+                }
+            },
+            [server]
         )
-        const data = await res.json()
-        if (data.characters.length === 0) {
-            return {
-                ccaddress: '',
-                username: 'anonymous',
-                avatar: '',
-                description: '',
-                homestream: '',
-                notificationstream: ''
-            }
-        }
-        const payload = JSON.parse(data.characters[0].payload)
-        return {
-            ccaddress: data.characters[0].author,
-            username: payload.username,
-            avatar: payload.avatar,
-            description: payload.description,
-            homestream: payload.home,
-            notificationstream: payload.notification
-        }
-    })
+    )
 
-    const messageDict = useResourceManager<RTMMessage>(async (key: string) => {
-        const res = await fetch(server + `messages/${key}`, {
-            method: 'GET',
-            headers: {}
-        })
-        const data = await res.json()
-        return data.message
-    })
+    const messageDict = useResourceManager<RTMMessage>(
+        useCallback(
+            async (key: string) => {
+                const res = await fetch(server + `messages/${key}`, {
+                    method: 'GET',
+                    headers: {}
+                })
+                const data = await res.json()
+                return data.message
+            },
+            [server]
+        )
+    )
 
     const streamDict = useResourceManager<Stream>(async (key: string) => {
         const res = await fetch(server + `stream?stream=${key}`, {
@@ -286,7 +301,9 @@ function App(): JSX.Element {
                     userAddress: address,
                     emojiDict,
                     profile,
-                    streamDict
+                    streamDict,
+                    userDict,
+                    messageDict
                 }}
             >
                 <BrowserRouter>
@@ -334,8 +351,6 @@ function App(): JSX.Element {
                                         element={
                                             <Timeline
                                                 messages={messages}
-                                                messageDict={messageDict}
-                                                userDict={userDict}
                                                 follow={follow}
                                                 followList={followList}
                                                 setCurrentStreams={
@@ -357,7 +372,6 @@ function App(): JSX.Element {
                                                 setWatchList={setWatchStreams}
                                                 followList={followList}
                                                 setFollowList={setFollowList}
-                                                userDict={userDict}
                                             />
                                         }
                                     />

--- a/src/components/TimelineMessage.tsx
+++ b/src/components/TimelineMessage.tsx
@@ -24,7 +24,6 @@ import BoringAvatar from 'boring-avatars'
 
 import { ApplicationContext } from '../App'
 import { type Emoji, type RTMMessage, type User } from '../model'
-import { type IuseResourceManager } from '../hooks/useResourceManager'
 import { Schemas } from '../schemas'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -38,8 +37,6 @@ import { materialDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
 
 export interface TimelineMessageProps {
     message: string
-    messageDict: IuseResourceManager<RTMMessage>
-    userDict: IuseResourceManager<User>
     follow: (ccaddress: string) => void
 }
 
@@ -59,11 +56,11 @@ export function TimelineMessage(props: TimelineMessageProps): JSX.Element {
     const [inspectItem, setInspectItem] = useState<RTMMessage | null>(null)
 
     const loadTweet = (): void => {
-        props.messageDict
+        appData.messageDict
             .get(props.message)
             .then((msg) => {
                 setMessage(msg)
-                props.userDict
+                appData.userDict
                     .get(msg.author)
                     .then((user) => {
                         setUser(user)
@@ -102,9 +99,9 @@ export function TimelineMessage(props: TimelineMessageProps): JSX.Element {
         const payloadObj = {}
         const payload = JSON.stringify(payloadObj)
         const signature = Sign(appData.privatekey, payload)
-        const targetAuthor = (await props.messageDict.get(messageID)).author
+        const targetAuthor = (await appData.messageDict.get(messageID)).author
         console.log(targetAuthor)
-        const targetStream = (await props.userDict.get(targetAuthor))
+        const targetStream = (await appData.userDict.get(targetAuthor))
             .notificationstream
         console.log([targetStream].filter((e) => e))
 
@@ -124,7 +121,7 @@ export function TimelineMessage(props: TimelineMessageProps): JSX.Element {
         fetch(appData.serverAddress + 'associations', requestOptions)
             .then(async (res) => await res.json())
             .then((_) => {
-                props.messageDict.invalidate(messageID)
+                appData.messageDict.invalidate(messageID)
                 loadTweet()
             })
     }
@@ -146,7 +143,7 @@ export function TimelineMessage(props: TimelineMessageProps): JSX.Element {
         fetch(appData.serverAddress + 'associations', requestOptions)
             .then(async (res) => await res.json())
             .then((_) => {
-                props.messageDict.invalidate(messageID)
+                appData.messageDict.invalidate(messageID)
                 loadTweet()
             })
     }

--- a/src/hooks/useResourceManager.ts
+++ b/src/hooks/useResourceManager.ts
@@ -34,3 +34,16 @@ export function useResourceManager<T>(
         invalidate
     }
 }
+
+export const dummyResourceManager: IuseResourceManager<any> = {
+    current: {},
+    get: async () => {
+        throw new Error('ResourceManager not initialized get')
+    },
+    register: (key: string, value: any) => {
+        throw new Error('ResourceManager not initialized register')
+    },
+    invalidate: (key: string) => {
+        throw new Error('ResourceManager not initialized invalidate')
+    }
+}

--- a/src/pages/Explorer.tsx
+++ b/src/pages/Explorer.tsx
@@ -17,7 +17,6 @@ import { useContext, useEffect, useState } from 'react'
 import { ApplicationContext } from '../App'
 import StarIcon from '@mui/icons-material/Star'
 import StarBorderIcon from '@mui/icons-material/StarBorder'
-import type { IuseResourceManager } from '../hooks/useResourceManager'
 import type { Stream, User } from '../model'
 import { Sign } from '../util'
 
@@ -26,7 +25,6 @@ export interface ExplorerProps {
     followList: string[]
     setFollowList: (newlist: string[]) => void
     setWatchList: (newlist: string[]) => void
-    userDict: IuseResourceManager<User>
 }
 
 export function Explorer(props: ExplorerProps): JSX.Element {
@@ -87,7 +85,8 @@ export function Explorer(props: ExplorerProps): JSX.Element {
             setFollowList(
                 await Promise.all(
                     props.followList.map(
-                        async (ccaddress) => await props.userDict.get(ccaddress)
+                        async (ccaddress) =>
+                            await appData.userDict.get(ccaddress)
                     )
                 )
             )

--- a/src/pages/Timeline.tsx
+++ b/src/pages/Timeline.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback, useContext, useEffect } from 'react'
 import { List, Divider, Box, useTheme } from '@mui/material'
 import { TimelineMessage } from '../components/TimelineMessage'
-import { type RTMMessage, type StreamElement, type User } from '../model'
-import { type IuseResourceManager } from '../hooks/useResourceManager'
+import { type StreamElement } from '../model'
 import { type IuseObjectList } from '../hooks/useObjectList'
 import { Draft } from '../components/Draft'
 import { StreamsBar } from '../components/StreamsBar'
@@ -11,8 +10,6 @@ import { ApplicationContext } from '../App'
 
 export interface TimelineProps {
     messages: IuseObjectList<StreamElement>
-    userDict: IuseResourceManager<User>
-    messageDict: IuseResourceManager<RTMMessage>
     follow: (ccaddress: string) => void
     followList: string[]
     setCurrentStreams: (input: string) => void
@@ -35,7 +32,7 @@ export function Timeline(props: TimelineProps): JSX.Element {
                     props.followList.map(
                         async (ccaddress) =>
                             (
-                                await props.userDict.get(ccaddress)
+                                await appData.userDict.get(ccaddress)
                             ).homestream
                     )
                 )
@@ -78,7 +75,7 @@ export function Timeline(props: TimelineProps): JSX.Element {
                         props.followList.map(
                             async (ccaddress) =>
                                 (
-                                    await props.userDict.get(ccaddress)
+                                    await appData.userDict.get(ccaddress)
                                 ).homestream
                         )
                     )
@@ -121,8 +118,6 @@ export function Timeline(props: TimelineProps): JSX.Element {
                                 <React.Fragment key={e.ID}>
                                     <TimelineMessage
                                         message={e.Values.id}
-                                        messageDict={props.messageDict}
-                                        userDict={props.userDict}
                                         follow={props.follow}
                                     />
                                     <Divider


### PR DESCRIPTION
### Title
messageDictとuserDictをcontextに移動する

### Ticket
issue #60

### Changes
- messageDict / userDict を  ApplicationContext へ移動
  - useCallback での再生成抑制
  - props 渡しを廃止し appData から直接呼び出し
- dummyResourceManager を追加
  - 未初期化時に呼び出された際のケア

### ToDo
- エラーハンドリング周辺
