### PR TITLE
add delay

### DIFF
--- a/src/components/Timeline/Message/MessageView.tsx
+++ b/src/components/Timeline/Message/MessageView.tsx
@@ -44,6 +44,7 @@ export const MessageView = (props: MessageViewProps): JSX.Element => {
                     <Tooltip
                         enterDelay={500}
                         enterNextDelay={500}
+                        leaveDelay={300}
                         placement="top"
                         components={{
                             Tooltip: Paper


### PR DESCRIPTION
ユーザプロフィールのToolTipはマウスを外すとすぐなくなってフローボタンを押しにくいので、マウス外す時の遅延と追加しました。