### PR TITLE
fix: add private key validation for account import screen

### DIFF
--- a/src/pages/AccountImport.tsx
+++ b/src/pages/AccountImport.tsx
@@ -5,7 +5,7 @@ import Paper from '@mui/material/Paper'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import { useEffect, useState } from 'react'
-import { LoadKey } from '../util'
+import { LoadKey, isValid256k1PrivateKey } from '../util'
 import { useNavigate } from 'react-router-dom'
 import { HDNodeWallet } from 'ethers'
 import { LangJa } from '../utils/lang-ja'
@@ -48,6 +48,10 @@ export function AccountImport(): JSX.Element {
         setErrorMessage('')
         setEntityFound(false)
         if (mnemonic === '') {
+            if (!isValid256k1PrivateKey(secret)) {
+                setErrorMessage('秘密鍵の要件を満たしていません。秘密鍵でないか入力に誤りがあります。')
+                return
+            }
             const key = LoadKey(secret)
             if (!key) return
             privatekey = key.privatekey

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -61,6 +61,13 @@ export const validateSignature = (body: string, signature: string, expectedAutho
     return recovered.slice(2) === expectedAuthor.slice(2)
 }
 
+export const isValid256k1PrivateKey = (key: string): boolean => {
+    if (!/^[0-9a-f]{64}$/i.test(key)) return false
+    const privateKey = BigInt(`0x${key}`)
+    const n = BigInt('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141')
+    return privateKey > BigInt(0) && privateKey < n
+}
+
 export const Sign = (privatekey: string, payload: string): string => {
     const ellipsis = new Ec('secp256k1')
     const keyPair = ellipsis.keyFromPrivate(privatekey)
@@ -112,17 +119,21 @@ export const Keygen = (): key => {
 }
 
 export const LoadKey = (privateKey: string): key | null => {
-    const ellipsis = new Ec('secp256k1')
-    const keyPair = ellipsis.keyFromPrivate(privateKey)
-    if (!keyPair.getPrivate()) return null
-    const privatekey = keyPair.getPrivate().toString('hex')
-    const publickey = keyPair.getPublic().encode('hex', false)
-    const ethAddress = computeAddress('0x' + publickey)
-    const ccaddress = 'CC' + ethAddress.slice(2)
-    return {
-        privatekey,
-        publickey,
-        ccaddress
+    try {
+        const ellipsis = new Ec('secp256k1')
+        const keyPair = ellipsis.keyFromPrivate(privateKey)
+        if (!keyPair.getPrivate()) return null
+        const privatekey = keyPair.getPrivate().toString('hex')
+        const publickey = keyPair.getPublic().encode('hex', false)
+        const ethAddress = computeAddress('0x' + publickey)
+        const ccaddress = 'CC' + ethAddress.slice(2)
+        return {
+            privatekey,
+            publickey,
+            ccaddress
+        }
+    } catch (error) {
+        return null
     }
 }
 


### PR DESCRIPTION
### Issue
アカウントインポート画面の秘密鍵の入力を検証する #283

### Changes
- 検証関数の追加
  - isValid256k1PrivateKey()
- エラーメッセージの追加
  - 「秘密鍵の要件を満たしていません。秘密鍵でないか入力に誤りがあります。」

### Please review
- 検証ロジックに問題がないかどうか
  - 64文字の16進数列であること
  - secp256k1の位数nより小さいこと