### PR TITLE
Feat/fix required destination

### DIFF
--- a/src/components/Draft.tsx
+++ b/src/components/Draft.tsx
@@ -477,7 +477,11 @@ export const Draft = memo<DraftProps>((props: DraftProps): JSX.Element => {
                             variant="contained"
                             disabled={sending}
                             onClick={(_) => {
-                                post()
+                                if (destStreams.length === 0 && !postHome) {
+                                    enqueueSnackbar('set destination required', { variant: 'error' })
+                                } else {
+                                    post()
+                                }
                             }}
                             sx={{
                                 '&.Mui-disabled': {

--- a/src/components/Draft.tsx
+++ b/src/components/Draft.tsx
@@ -88,6 +88,10 @@ export const Draft = memo<DraftProps>((props: DraftProps): JSX.Element => {
             enqueueSnackbar('Message must not be empty!', { variant: 'error' })
             return
         }
+        if (destStreams.length === 0 && !postHome) {
+            enqueueSnackbar('set destination required', { variant: 'error' })
+            return
+        }
         const destStreamIDs = destStreams.map((s) => s.id)
         const dest = [
             ...new Set([...destStreamIDs, ...(postHome ? [client?.user?.userstreams?.homeStream] : [])])
@@ -477,11 +481,7 @@ export const Draft = memo<DraftProps>((props: DraftProps): JSX.Element => {
                             variant="contained"
                             disabled={sending}
                             onClick={(_) => {
-                                if (destStreams.length === 0 && !postHome) {
-                                    enqueueSnackbar('set destination required', { variant: 'error' })
-                                } else {
-                                    post()
-                                }
+                                post()
                             }}
                             sx={{
                                 '&.Mui-disabled': {


### PR DESCRIPTION
#319 に対する修正
・POSTボタンクリック時にdestStreamsが空かつpostHomeがfalseの場合(投稿先ストリームも指定されておらず、ストリーム限定投稿モードになっている場合)に、エラーを表示するように修正

確認お願します🙇