### PR TITLE
#307 Feat/avatar username failure fix

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -38,7 +38,7 @@ const branchName = branch || window.location.host.split('.')[0]
 
 export interface MenuProps {
     onClick?: () => void
-    user?: User
+    user?: User | null | undefined
 }
 
 export const Menu = memo<MenuProps>((props: MenuProps): JSX.Element => {

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -83,7 +83,7 @@ export const Menu = memo<MenuProps>((props: MenuProps): JSX.Element => {
                         onClick={props.onClick}
                     >
                         <CCAvatar
-                            avatarURL={props?.user?.profile?.avatar}
+                            avatarURL={props?.user?.profile?.avatar ?? client?.user?.profile?.avatar}
                             identiconSource={client.ccid}
                             sx={{
                                 width: '40px',
@@ -91,7 +91,9 @@ export const Menu = memo<MenuProps>((props: MenuProps): JSX.Element => {
                             }}
                         />
                         <Box sx={{ flex: 1, display: 'flex', justifyContent: 'center', flexFlow: 'column' }}>
-                            <Typography color="contrastText">{props?.user?.profile?.username}</Typography>
+                            <Typography color="contrastText">
+                                {props?.user?.profile?.username ?? client?.user?.profile?.username}
+                            </Typography>
                             <Typography variant="caption" color="background.contrastText">
                                 {client.api.host}
                             </Typography>

--- a/src/context/GlobalActions.tsx
+++ b/src/context/GlobalActions.tsx
@@ -315,6 +315,7 @@ export const GlobalActionsProvider = (props: GlobalActionsProps): JSX.Element =>
                     onClick={() => {
                         setMobileMenuOpen(false)
                     }}
+                    user={client.user}
                 />
             </Drawer>
         </GlobalActionsContext.Provider>


### PR DESCRIPTION
#307
度々ごめんなさい💦
スマホレイアウト時のドロワー内のアイコンが読み込まれていなかったので修正しました...

〇 スマホレイアウトのドロワー内のユーザーアイコンが読み込まれていなかったため修正
〇 ユーザーアイコンとユーザー名がpropsでセットされていない場合、従来の方法で取得を試みるように修正

お手数をおかけしてごめんなさい。
確認のほどよろしくお願いします🙇💦