### PR TITLE
#107に対する修正: 無限スクロールのloadingアイコンの表示タイミング最適化

### DIFF
--- a/src/components/ui/Loading.tsx
+++ b/src/components/ui/Loading.tsx
@@ -1,5 +1,7 @@
 import { Box, Typography } from '@mui/material'
 import { ConcurrentLogo } from '../theming/ConcurrentLogo'
+import { useOnScreen } from '../../hooks/useOnScreen'
+import React from 'react'
 
 export interface LoadingProps {
     message: string
@@ -7,25 +9,30 @@ export interface LoadingProps {
 }
 
 export const Loading = (props: LoadingProps): JSX.Element => {
+    const ref: React.RefObject<any> = React.createRef()
+    const targetViewPosition = useOnScreen(ref)
     return (
-        <Box
-            sx={{
-                color: props.color,
-                display: 'flex',
-                flexDirection: 'row',
-                alignItems: 'center',
-                justifyContent: 'center',
-                gap: 1
-            }}
-        >
-            <ConcurrentLogo
-                size="30px"
-                upperColor={props.color}
-                lowerColor={props.color}
-                frameColor={props.color}
-                spinning={true}
-            />
-            <Typography variant="body1">{props.message}</Typography>
-        </Box>
+        <div ref={ref}>
+            <Box
+                ref={ref}
+                sx={{
+                    color: props.color,
+                    display: targetViewPosition === 'VISIBLE' ? 'flex' : 'none',
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: 1
+                }}
+            >
+                <ConcurrentLogo
+                    size="30px"
+                    upperColor={props.color}
+                    lowerColor={props.color}
+                    frameColor={props.color}
+                    spinning={true}
+                />
+                <Typography variant="body1">{props.message}</Typography>
+            </Box>
+        </div>
     )
 }

--- a/src/hooks/useOnScreen.ts
+++ b/src/hooks/useOnScreen.ts
@@ -1,0 +1,38 @@
+import type React from 'react'
+import { useState, useEffect } from 'react'
+
+type TargetViewPosition = undefined | 'ABOVE_VIEWPORT' | 'BELOW_VIEWPORT' | 'VISIBLE'
+
+export function useOnScreen(targetRef: React.RefObject<HTMLElement>): TargetViewPosition {
+    const [targetViewPosition, setTargetViewPosition] = useState<TargetViewPosition>(undefined)
+
+    const observer = new IntersectionObserver(
+        ([entry]) => {
+            if (entry.isIntersecting) {
+                setTargetViewPosition('VISIBLE') // 画面内に表示中
+                return
+            }
+            if (entry.boundingClientRect.top > 0) {
+                setTargetViewPosition('BELOW_VIEWPORT') // 画面より下に表示中
+            } else {
+                setTargetViewPosition('ABOVE_VIEWPORT') // 画面より上に表示中
+            }
+        },
+        {
+            root: null,
+            threshold: 0
+        }
+    )
+
+    useEffect(() => {
+        // マウント時にobserverを登録
+        if (targetRef.current) observer.observe(targetRef.current)
+
+        // アンマウント時にobserverを解除
+        return () => {
+            observer.disconnect()
+        }
+    }, [])
+
+    return targetViewPosition
+}


### PR DESCRIPTION
#107 
追加読み込み時に表示されるloadingアイコンがviewport(表示領域)外にある場合、非表示にしてCPUの使用率を抑えるように修正しました。